### PR TITLE
Removed the hideKeyboardWhenSelected property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+v1.0.6
+----------
+* Removed the hideKeyboardWhenSelected property. This property seemed too specific. To hide the keyboard when selecting a field, an alternative workaround is to set the textField.inputView property to an empty view.
+
 v1.0.5
 ----------
 * Added the hideKeyboardWhenSelected property

--- a/SkyFloatingLabelTextField.podspec
+++ b/SkyFloatingLabelTextField.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
   s.name = "SkyFloatingLabelTextField"
-  s.version = "1.0.5"
+  s.version = "1.0.6"
   s.summary = "A beautiful, flexible and customizable textfield that minimizes space when displaying additional context."
   s.homepage = "https://github.com/Skyscanner/SkyFloatingLabelTextField"
   s.license = { :type => "Apache 2.0", :file => "LICENSE.md" }
   s.authors = "Daniel Langh, Gergely Orosz, Raimon Lapuente"
   s.ios.deployment_target = "8.0"
-  s.source = { :git => "https://github.com/Skyscanner/SkyFloatingLabelTextField.git", :tag => "v1.0.5" }
+  s.source = { :git => "https://github.com/Skyscanner/SkyFloatingLabelTextField.git", :tag => "v1.0.6" }
   s.source_files = 'Sources/*.swift'
 end

--- a/SkyFloatingLabelTextField/SkyFloatingLabelTextFieldTests/SkyFloatingLabelTextFieldTests.swift
+++ b/SkyFloatingLabelTextField/SkyFloatingLabelTextFieldTests/SkyFloatingLabelTextFieldTests.swift
@@ -314,26 +314,6 @@ class SkyFloatingLabelTextFieldTests: XCTestCase {
         XCTAssertTrue(floatingLabelTextField.textField.secureTextEntry)
     }
     
-    func test_whenSettingHideKeyboardWhenSelectedToTrue_thenTextFieldInputViewIsAnEmptyView() {
-        // when
-        floatingLabelTextField.hideKeyboardWhenSelected = true
-        
-        // them
-        XCTAssertEqual(floatingLabelTextField.textField.inputView!.frame.width, 0)
-        XCTAssertEqual(floatingLabelTextField.textField.inputView!.frame.height, 0)
-    }
-    
-    func test_whenChangingHideKeyboardWhenSelectedToFalse_thenTextFieldInputViewIsSetToNil() {
-        // given
-        floatingLabelTextField.hideKeyboardWhenSelected = true
-        
-        // when
-        floatingLabelTextField.hideKeyboardWhenSelected = false
-        
-        // them
-        XCTAssertNil(floatingLabelTextField.textField.inputView)
-    }
-    
     func test_whenGettingEnabledValue_thenReturnsPreviouslySetValue() {
         // given
         XCTAssertTrue(floatingLabelTextField.enabled)

--- a/Sources/SkyFloatingLabelTextField.swift
+++ b/Sources/SkyFloatingLabelTextField.swift
@@ -119,17 +119,6 @@ public class SkyFloatingLabelTextField: UIControl, UITextFieldDelegate {
     
     private var emptyKeyboardView: UIView = UIView()
     
-    /// A bool value that determines whether the keyboard should be shown when the field is selected
-    public var hideKeyboardWhenSelected:Bool = false {
-        didSet {
-            if(self.hideKeyboardWhenSelected) {
-                self.textField.inputView = emptyKeyboardView
-            } else {
-                self.textField.inputView =  nil
-            }
-        }
-    }
-    
     /**
      Identifies whether the text object should hide the text being entered.
      */


### PR DESCRIPTION
This property seemed too specific. To hide the keyboard when selecting
a field, an alternative workaround is to set the textField.inputView
property to an empty view.