### PR TITLE
Remove unnecessary business logic from errorMessage

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,10 +120,13 @@ class MyViewController: UIViewController, UITextFieldDelegate {
     /// Implementing a method on the UITextFieldDelegate protocol. This will notify us when something has changed on the textfield
     func textField(textField: UITextField, shouldChangeCharactersInRange range: NSRange, replacementString string: String) -> Bool {
         if let text = textField.text {
-            // Note: every time when the text of the textfield changes, the error message is reset (hence we don't need to reset it)
-            if(text.characters.count < 3 || !text.containsString("@")) {
-                if let floatingLabelTextField = textField as? SkyFloatingLabelTextField {
-                    floatingLabelTextField.errorMessage = "Invaid email"
+            if let floatingLabelTextField = textField as? SkyFloatingLabelTextField {
+                if(text.characters.count < 3 || !text.containsString("@")) {
+                    floatingLabelTextField.errorMessage = "Invalid email"
+                }
+                else {
+                    // The error message will only disappear when we reset it to nil or empty string
+                    floatingLabelTextField.errorMessage = ""
                 }
             }
         }
@@ -135,12 +138,12 @@ class MyViewController: UIViewController, UITextFieldDelegate {
 ### Further customizing the control by subclassing
 
 The control was designed to allow further customization in subclasses. The control itself inherits from `UITextField`, so the standard overrides from there can all be used. A few other notable customization hooks via overriding are:
-- `updateColors`: override this method to customzie colors whenever the state of the control changes
-- Layout overrrides:
+- `updateColors`: override this method to customize colors whenever the state of the control changes
+- Layout overrides:
   - `titleLabelRectForBounds(bounds:CGRect, editing:Bool)`:  override to change the bounds of the top title placeholder view
   - `textRectForBounds(bounds: CGRect)`: override to change the bounds of the control (inherited from `UITextField`)
   - `editingRectForBounds(bounds: CGRect)`: override to change the bounds of the control when editing / selected (inherited from `UITextField`)
-  - `placeholderRectForBounds(bounds: CGRect)`:  override to change the bounds of the placeholder view 
+  - `placeholderRectForBounds(bounds: CGRect)`:  override to change the bounds of the placeholder view
   - `lineViewRectForBounds(bounds:CGRect, editing:Bool)`: override to change the bounds of the bottom line view
 
 ## Documentation
@@ -162,7 +165,7 @@ Then simply add `SkyFloatingLabelTextField` to your Podfile:
 pod 'SkyFloatingLabelTextField', '~> 1.0'
 ```
 
-Lastly let CocoaPods fetch the latest version of the component by running:
+Lastly, let CocoaPods fetch the latest version of the component by running:
 ```shell
 $ cocoapods update
 ```
@@ -219,8 +222,12 @@ Credits for the original design, and improving it with iconography to Matt D. Sm
 
 - *Does the control work well with auto layout? What about using it programmatically?*
 
-  The control was built to support both use cases. It plays nicely with autolayout. As the control is a subclass of `UITextField`, overriding `textRectForBounds(bounds:)` or `editingRectForBounds(bounds:)` is always an option. Alternatively, overriding `intrinsiccontentsize` is also another possiblity.
+  The control was built to support both use cases. It plays nicely with autolayout. As the control is a subclass of `UITextField`, overriding `textRectForBounds(bounds:)` or `editingRectForBounds(bounds:)` is always an option. Alternatively, overriding `intrinsiccontentsize` is also another possibility.
 
 - *How can I remove the line from the bottom of the textfield?*
 
   Set `lineHeight` and `selectedLineHeight` to `0`, and the line won't be displayed.
+
+- *I'd like to validate the textfield using the `errorMessage`. How can I re-validate text is typed in the textfield?*
+
+  Using a delegate implement the `textField(textField:,range:string:)` method. This method fires whenever the text is changed - do the validation here. Alternatively, using subclassing you can also override the `becomeFirstResponder` method to e.g. clear the text or error message when the textfield is selected.

--- a/SkyFloatingLabelTextField/SkyFloatingLabelTextFieldExample/Base.lproj/Main.storyboard
+++ b/SkyFloatingLabelTextField/SkyFloatingLabelTextFieldExample/Base.lproj/Main.storyboard
@@ -40,13 +40,13 @@
                                 </connections>
                             </segmentedControl>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Selected title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="I1P-U3-aHP">
-                                <rect key="frame" x="149" y="232" width="104" height="21"/>
+                                <rect key="frame" x="148" y="232" width="104" height="21"/>
                                 <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="1" translatesAutoresizingMaskIntoConstraints="NO" id="mZq-8q-kvm">
-                                <rect key="frame" x="148" y="382" width="105" height="29"/>
+                                <rect key="frame" x="148" y="383" width="105" height="29"/>
                                 <segments>
                                     <segment title="None"/>
                                     <segment title="&quot;Title&quot;"/>
@@ -56,13 +56,13 @@
                                 </connections>
                             </segmentedControl>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="v9J-yM-eLO">
-                                <rect key="frame" x="183" y="353" width="35" height="21"/>
+                                <rect key="frame" x="183" y="354" width="35" height="21"/>
                                 <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="1" translatesAutoresizingMaskIntoConstraints="NO" id="Q90-lp-2pi">
-                                <rect key="frame" x="103" y="503" width="195" height="29"/>
+                                <rect key="frame" x="103" y="505" width="195" height="29"/>
                                 <segments>
                                     <segment title="None"/>
                                     <segment title="&quot;Placeholder&quot;"/>
@@ -72,7 +72,7 @@
                                 </connections>
                             </segmentedControl>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Placeholder" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="moI-xd-AVZ">
-                                <rect key="frame" x="154" y="474" width="93" height="21"/>
+                                <rect key="frame" x="154" y="476" width="93" height="21"/>
                                 <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
@@ -98,13 +98,13 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title is visible when the control is not editing and input text is at least 1 character long" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wjk-mj-9y9">
-                                <rect key="frame" x="20" y="418" width="360" height="27"/>
+                                <rect key="frame" x="20" y="419" width="360" height="27"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="11"/>
                                 <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yWR-GY-MZc">
-                                <rect key="frame" x="20" y="539" width="360" height="40"/>
+                                <rect key="frame" x="20" y="541" width="360" height="40"/>
                                 <string key="text">Placeholder is visible when no input text is present or when input text is at least 1 character long and neither title nor selected title is present</string>
                                 <fontDescription key="fontDescription" type="system" pointSize="11"/>
                                 <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
@@ -146,6 +146,7 @@
                     <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
                     <size key="freeformSize" width="400" height="600"/>
                     <connections>
+                        <outlet property="addErrorButton" destination="Pgz-Tf-Rvl" id="YRU-QW-c8B"/>
                         <outlet property="textField" destination="SqB-4f-slo" id="X0q-jS-821"/>
                     </connections>
                 </viewController>
@@ -192,10 +193,10 @@
                                 </connections>
                             </button>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="alE-Hq-VDg">
-                                <rect key="frame" x="20" y="219" width="180" height="321"/>
+                                <rect key="frame" x="20" y="219" width="180" height="323"/>
                                 <subviews>
                                     <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" translatesAutoresizingMaskIntoConstraints="NO" id="OhG-wy-aBa">
-                                        <rect key="frame" x="19" y="56" width="143" height="29"/>
+                                        <rect key="frame" x="19" y="57" width="143" height="29"/>
                                         <segments>
                                             <segment title="⚪️"/>
                                             <segment title="🔴 "/>
@@ -213,7 +214,7 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" translatesAutoresizingMaskIntoConstraints="NO" id="6Ya-gn-vtf">
-                                        <rect key="frame" x="19" y="136" width="143" height="29"/>
+                                        <rect key="frame" x="19" y="137" width="143" height="29"/>
                                         <segments>
                                             <segment title="⚪️"/>
                                             <segment title="🔴 "/>
@@ -225,13 +226,13 @@
                                         </connections>
                                     </segmentedControl>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Placeholder color" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eRP-1f-9dO">
-                                        <rect key="frame" x="21" y="107" width="137" height="21"/>
+                                        <rect key="frame" x="21" y="108" width="137" height="21"/>
                                         <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
                                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" translatesAutoresizingMaskIntoConstraints="NO" id="bD7-hR-7wM">
-                                        <rect key="frame" x="18" y="214" width="143" height="29"/>
+                                        <rect key="frame" x="18" y="216" width="143" height="29"/>
                                         <segments>
                                             <segment title="⚪️"/>
                                             <segment title="🔴 "/>
@@ -243,19 +244,19 @@
                                         </connections>
                                     </segmentedControl>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Text color" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="q1u-4f-EEP">
-                                        <rect key="frame" x="51" y="185" width="78" height="21"/>
+                                        <rect key="frame" x="51" y="186" width="78" height="21"/>
                                         <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
                                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Error color" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="q7U-ur-hzY">
-                                        <rect key="frame" x="48" y="259" width="83" height="21"/>
+                                        <rect key="frame" x="48" y="261" width="83" height="21"/>
                                         <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
                                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" translatesAutoresizingMaskIntoConstraints="NO" id="xDl-bN-AMF">
-                                        <rect key="frame" x="19" y="288" width="143" height="29"/>
+                                        <rect key="frame" x="19" y="290" width="143" height="29"/>
                                         <segments>
                                             <segment title="⚪️"/>
                                             <segment title="🔴 "/>
@@ -289,7 +290,7 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="VgJ-VD-7rc">
-                                <rect key="frame" x="200" y="219" width="180" height="321"/>
+                                <rect key="frame" x="200" y="219" width="180" height="323"/>
                                 <subviews>
                                     <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="bordered" translatesAutoresizingMaskIntoConstraints="NO" id="sId-82-UKI">
                                         <rect key="frame" x="19" y="57" width="143" height="29"/>
@@ -310,7 +311,7 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" translatesAutoresizingMaskIntoConstraints="NO" id="iAR-Dy-4tD">
-                                        <rect key="frame" x="19" y="136" width="143" height="29"/>
+                                        <rect key="frame" x="19" y="137" width="143" height="29"/>
                                         <segments>
                                             <segment title="⚪️"/>
                                             <segment title="🔴 "/>
@@ -328,7 +329,7 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" translatesAutoresizingMaskIntoConstraints="NO" id="aU8-tN-vcw">
-                                        <rect key="frame" x="18" y="215" width="143" height="29"/>
+                                        <rect key="frame" x="18" y="216" width="143" height="29"/>
                                         <segments>
                                             <segment title="⚪️"/>
                                             <segment title="🔴 "/>
@@ -337,19 +338,19 @@
                                         </segments>
                                     </segmentedControl>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="None" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3TY-KI-uu5">
-                                        <rect key="frame" x="69" y="185" width="42" height="21"/>
+                                        <rect key="frame" x="69" y="186" width="42" height="21"/>
                                         <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
                                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="None" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Q1Y-Jd-kwO">
-                                        <rect key="frame" x="69" y="260" width="42" height="21"/>
+                                        <rect key="frame" x="69" y="261" width="42" height="21"/>
                                         <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
                                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" translatesAutoresizingMaskIntoConstraints="NO" id="AcC-l7-4xT">
-                                        <rect key="frame" x="19" y="288" width="143" height="29"/>
+                                        <rect key="frame" x="19" y="290" width="143" height="29"/>
                                         <segments>
                                             <segment title="⚪️"/>
                                             <segment title="🔴 "/>
@@ -406,6 +407,7 @@
                     <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
                     <size key="freeformSize" width="400" height="600"/>
                     <connections>
+                        <outlet property="addErrorButton" destination="8Re-re-tpi" id="ZOl-cL-8Hs"/>
                         <outlet property="textField" destination="uNV-WR-pyn" id="Gre-9c-B1w"/>
                     </connections>
                 </viewController>
@@ -465,6 +467,7 @@
                     <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
                     <size key="freeformSize" width="400" height="600"/>
                     <connections>
+                        <outlet property="addErrorButton" destination="nJD-aY-w9P" id="e4A-28-mFV"/>
                         <outlet property="textField" destination="Osc-Na-BFz" id="S26-QJ-vk9"/>
                     </connections>
                 </viewController>
@@ -531,6 +534,7 @@
                     <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
                     <size key="freeformSize" width="400" height="600"/>
                     <connections>
+                        <outlet property="addErrorButton" destination="5HI-11-MA2" id="7jV-9q-4ej"/>
                         <outlet property="logTextView" destination="RbV-ew-j6J" id="YBJ-Wx-fBD"/>
                         <outlet property="textField" destination="1BP-H7-VvG" id="QgK-iN-1Jg"/>
                     </connections>
@@ -604,6 +608,7 @@ In this example an icon label is added and placeholder label and textfield are p
                     <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
                     <size key="freeformSize" width="400" height="600"/>
                     <connections>
+                        <outlet property="addErrorButton" destination="Iv1-md-6Bi" id="2LA-gE-s5q"/>
                         <outlet property="textField" destination="teF-Dw-L0V" id="PkX-BQ-9fm"/>
                     </connections>
                 </viewController>
@@ -633,7 +638,7 @@ In this example an icon label is added and placeholder label and textfield are p
                                         <rect key="frame" x="0.0" y="353" width="400" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="9Ic-jU-0kD" id="n5V-PH-Xpt">
-                                            <rect key="frame" x="0.0" y="0.0" width="367" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="367" height="43"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Setting text properties" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HdC-wj-sIC">
@@ -657,7 +662,7 @@ In this example an icon label is added and placeholder label and textfield are p
                                         <rect key="frame" x="0.0" y="397" width="400" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Y6b-WS-83A" id="nF8-7o-rtc">
-                                            <rect key="frame" x="0.0" y="0.0" width="367" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="367" height="43"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Customizing colors" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jCk-47-jKB">
@@ -681,7 +686,7 @@ In this example an icon label is added and placeholder label and textfield are p
                                         <rect key="frame" x="0.0" y="441" width="400" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="rOq-H4-quk" id="hT2-6u-XHh">
-                                            <rect key="frame" x="0.0" y="0.0" width="367" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="367" height="43"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Theming by subclassing" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="09e-P3-DiE">
@@ -705,7 +710,7 @@ In this example an icon label is added and placeholder label and textfield are p
                                         <rect key="frame" x="0.0" y="485" width="400" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="8oo-Gf-1XP" id="381-SW-Nym">
-                                            <rect key="frame" x="0.0" y="0.0" width="367" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="367" height="43"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Custom layout by subclassing" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qSH-5l-bpY">
@@ -729,7 +734,7 @@ In this example an icon label is added and placeholder label and textfield are p
                                         <rect key="frame" x="0.0" y="529" width="400" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="RAK-ye-rqX" id="Lst-at-xEK">
-                                            <rect key="frame" x="0.0" y="0.0" width="367" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="367" height="43"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Using delegate methods" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="evz-m8-4qe">

--- a/SkyFloatingLabelTextField/SkyFloatingLabelTextFieldExample/Example0/ShowcaseExampleViewController.swift
+++ b/SkyFloatingLabelTextField/SkyFloatingLabelTextFieldExample/Example0/ShowcaseExampleViewController.swift
@@ -53,6 +53,31 @@ class ShowcaseExampleViewController: UIViewController, UITextFieldDelegate {
         self.titleField.delegate = self
         self.nameField.delegate = self
         self.emailField.delegate = self
+        
+        //self.arrivalCityField.errorMessage = "Please fill out this field"
+        
+        /*
+        Use cases:
+            - when error message is set, show it: wheter text is present, or not
+            - when text is set
+                - either clear error message
+                - or keep it
+            - when textfield is foucsed
+                - clear error message
+                - or keep it
+        
+            - default behaviour:
+                - when text is set, keep error message
+                - when textfield is focused, keep error message
+            - to change behaviour
+                - override setText to clear error message
+                - override becomeFirstResponder
+        */
+        
+        // errorMessageBehaviour
+        //  - showWhenTextI
+
+        //self.departureCityField.errorMessage = "Please fill out this field"
     }
     
     // MARK: - Styling the text fields to the Skyscanner theme
@@ -116,13 +141,7 @@ class ShowcaseExampleViewController: UIViewController, UITextFieldDelegate {
     func textFieldShouldReturn(textField: UITextField) -> Bool {
         // Validate the email field
         if (textField == self.emailField) {
-            if let email = self.emailField.text {
-                if(!isValidEmail(email)) {
-                    self.emailField.errorMessage = "Email not valid"
-                    return false
-                }
-            }
-            
+            validateEmailTextField()
         }
         
         // When pressing return, move to the next field
@@ -133,6 +152,26 @@ class ShowcaseExampleViewController: UIViewController, UITextFieldDelegate {
             textField.resignFirstResponder()
         }
         return false
+    }
+    
+    func textField(textField: UITextField, shouldChangeCharactersInRange range: NSRange, replacementString string: String) -> Bool {
+        self.validateEmailTextField()
+        return true
+    }
+    
+    func validateEmailTextField() {
+        if let email = self.emailField.text {
+            if(email.characters.count == 0) {
+                self.emailField.errorMessage = nil
+            }
+            else if(!isValidEmail(email)) {
+                self.emailField.errorMessage = "Email not valid"
+            } else {
+                self.emailField.errorMessage = nil
+            }
+        } else {
+             self.emailField.errorMessage = nil
+        }
     }
     
     func isValidEmail(str:String?) -> Bool {

--- a/SkyFloatingLabelTextField/SkyFloatingLabelTextFieldExample/Example0/ShowcaseExampleViewController.swift
+++ b/SkyFloatingLabelTextField/SkyFloatingLabelTextFieldExample/Example0/ShowcaseExampleViewController.swift
@@ -53,31 +53,6 @@ class ShowcaseExampleViewController: UIViewController, UITextFieldDelegate {
         self.titleField.delegate = self
         self.nameField.delegate = self
         self.emailField.delegate = self
-        
-        //self.arrivalCityField.errorMessage = "Please fill out this field"
-        
-        /*
-        Use cases:
-            - when error message is set, show it: wheter text is present, or not
-            - when text is set
-                - either clear error message
-                - or keep it
-            - when textfield is foucsed
-                - clear error message
-                - or keep it
-        
-            - default behaviour:
-                - when text is set, keep error message
-                - when textfield is focused, keep error message
-            - to change behaviour
-                - override setText to clear error message
-                - override becomeFirstResponder
-        */
-        
-        // errorMessageBehaviour
-        //  - showWhenTextI
-
-        //self.departureCityField.errorMessage = "Please fill out this field"
     }
     
     // MARK: - Styling the text fields to the Skyscanner theme

--- a/SkyFloatingLabelTextField/SkyFloatingLabelTextFieldExample/Example1/SettingTextsViewController.swift
+++ b/SkyFloatingLabelTextField/SkyFloatingLabelTextFieldExample/Example1/SettingTextsViewController.swift
@@ -12,8 +12,16 @@ class SettingTextsViewController: UIViewController {
 
     @IBOutlet var textField:SkyFloatingLabelTextField?
     
+    @IBOutlet var addErrorButton:UIButton?
+    
     @IBAction func addError() {
-        self.textField?.errorMessage = "error message"
+        if(self.addErrorButton?.titleForState(.Normal) == "Add error") {
+            self.textField?.errorMessage = "error message"
+            self.addErrorButton?.setTitle("Clear error", forState: .Normal)
+        } else {
+            self.textField?.errorMessage = ""
+            self.addErrorButton?.setTitle("Add error", forState: .Normal)
+        }
     }
     
     @IBAction func resignTextField() {

--- a/SkyFloatingLabelTextField/SkyFloatingLabelTextFieldExample/Example2/CustomizingColorsViewController.swift
+++ b/SkyFloatingLabelTextField/SkyFloatingLabelTextFieldExample/Example2/CustomizingColorsViewController.swift
@@ -12,8 +12,16 @@ class CustomizingColorsViewController: UIViewController {
 
     @IBOutlet weak var textField:SkyFloatingLabelTextField?
     
+    @IBOutlet var addErrorButton:UIButton?
+    
     @IBAction func addError() {
-        self.textField?.errorMessage = "error message"
+        if(self.addErrorButton?.titleForState(.Normal) == "Add error") {
+            self.textField?.errorMessage = "error message"
+            self.addErrorButton?.setTitle("Clear error", forState: .Normal)
+        } else {
+            self.textField?.errorMessage = ""
+            self.addErrorButton?.setTitle("Add error", forState: .Normal)
+        }
     }
     
     @IBAction func resignTextField() {

--- a/SkyFloatingLabelTextField/SkyFloatingLabelTextFieldExample/Example3/SubclassingViewController.swift
+++ b/SkyFloatingLabelTextField/SkyFloatingLabelTextFieldExample/Example3/SubclassingViewController.swift
@@ -19,8 +19,16 @@ class SubclassingViewController: UIViewController {
         self.view.tintColor = UIColor(red: 0.0, green: 221.0/256.0, blue: 238.0/256.0, alpha: 1.0)
     }
     
+    @IBOutlet var addErrorButton:UIButton?
+    
     @IBAction func addError() {
-        self.textField?.errorMessage = "error message"
+        if(self.addErrorButton?.titleForState(.Normal) == "Add error") {
+            self.textField?.errorMessage = "error message"
+            self.addErrorButton?.setTitle("Clear error", forState: .Normal)
+        } else {
+            self.textField?.errorMessage = ""
+            self.addErrorButton?.setTitle("Add error", forState: .Normal)
+        }
     }
     
     @IBAction func resignTextField() {

--- a/SkyFloatingLabelTextField/SkyFloatingLabelTextFieldExample/Example4/CustomLayoutViewController.swift
+++ b/SkyFloatingLabelTextField/SkyFloatingLabelTextFieldExample/Example4/CustomLayoutViewController.swift
@@ -12,8 +12,16 @@ class CustomLayoutViewController: UIViewController {
 
     @IBOutlet var textField:IconTextField?
     
+    @IBOutlet var addErrorButton:UIButton?
+    
     @IBAction func addError() {
-        self.textField?.errorMessage = "error message"
+        if(self.addErrorButton?.titleForState(.Normal) == "Add error") {
+            self.textField?.errorMessage = "error message"
+            self.addErrorButton?.setTitle("Clear error", forState: .Normal)
+        } else {
+            self.textField?.errorMessage = ""
+            self.addErrorButton?.setTitle("Add error", forState: .Normal)
+        }
     }
     
     @IBAction func resignTextField() {

--- a/SkyFloatingLabelTextField/SkyFloatingLabelTextFieldExample/Example5/DelegateMethodsViewController.swift
+++ b/SkyFloatingLabelTextField/SkyFloatingLabelTextFieldExample/Example5/DelegateMethodsViewController.swift
@@ -20,8 +20,16 @@ class DelegateMethodsViewController: UIViewController, UITextFieldDelegate {
         self.logTextView?.text = ""
     }
     
+    @IBOutlet var addErrorButton:UIButton?
+    
     @IBAction func addError() {
-        self.textField?.errorMessage = "error message"
+        if(self.addErrorButton?.titleForState(.Normal) == "Add error") {
+            self.textField?.errorMessage = "error message"
+            self.addErrorButton?.setTitle("Clear error", forState: .Normal)
+        } else {
+            self.textField?.errorMessage = ""
+            self.addErrorButton?.setTitle("Add error", forState: .Normal)
+        }
     }
     
     @IBAction func resignTextField() {

--- a/SkyFloatingLabelTextField/SkyFloatingLabelTextFieldTests/SkyFloatingLabelTextFieldTests.swift
+++ b/SkyFloatingLabelTextField/SkyFloatingLabelTextFieldTests/SkyFloatingLabelTextFieldTests.swift
@@ -188,7 +188,7 @@ class SkyFloatingLabelTextFieldTests: XCTestCase {
         XCTAssertFalse(floatingLabelTextField.hasText())
     }
     
-    func test_whenSettingText_withErrorMessagePresent_thenClearsErrorMessage() {
+    func test_whenSettingText_withErrorMessagePresent_thenErrorMessageIsNotChanged() {
         // given
         floatingLabelTextField.errorMessage = "error"
         floatingLabelTextField.title = "title"
@@ -198,11 +198,11 @@ class SkyFloatingLabelTextFieldTests: XCTestCase {
         floatingLabelTextField.text = "hello!"
         
         // then
-        XCTAssertEqual(floatingLabelTextField.titleLabel.text, "TITLE")
-        XCTAssertNil(floatingLabelTextField.errorMessage)
+        XCTAssertEqual(floatingLabelTextField.titleLabel.text, "ERROR")
+        XCTAssertEqual(floatingLabelTextField.errorMessage, "error")
     }
     
-    func test_whenBecomeFirstResponder_thenErrorMessageIsCleared() {
+    func test_whenBecomeFirstResponder_thenErrorMessageIsNotCleared() {
         // given
         floatingLabelTextField.errorMessage = "Error"
         
@@ -210,10 +210,10 @@ class SkyFloatingLabelTextFieldTests: XCTestCase {
         floatingLabelTextField.becomeFirstResponder()
         
         // then
-        XCTAssertNil(floatingLabelTextField.errorMessage)
+        XCTAssertEqual(floatingLabelTextField.errorMessage, "Error")
     }
     
-    func test_whenEditingChangedInvoked_thenErrorMessageIsCleared() {
+    func test_whenEditingChangedInvoked_thenErrorMessageIsNotCleared() {
         // given
         floatingLabelTextField.errorMessage = "Error"
         
@@ -221,12 +221,25 @@ class SkyFloatingLabelTextFieldTests: XCTestCase {
         floatingLabelTextField.editingChanged()
         
         // then
-        XCTAssertNil(floatingLabelTextField.errorMessage)
+        XCTAssertEqual(floatingLabelTextField.errorMessage, "Error")
     }
     
     func test_whenEditingChangedInvoked_thenDelegateShouldChangeCharactersInRangeInvoked() {
         // given
         floatingLabelTextField.delegate = textFieldDelegateMock
+        floatingLabelTextField.text = "aa"
+        
+        // when
+        floatingLabelTextField.editingChanged()
+        
+        // then
+        XCTAssertTrue(textFieldDelegateMock.shouldChangeCharactersInRangeInvoked)
+    }
+    
+    func test_whenEditingChangedInvoked2_thenDelegateShouldChangeCharactersInRangeInvoked() {
+        // given
+        floatingLabelTextField.delegate = textFieldDelegateMock
+        floatingLabelTextField.text = nil
         
         // when
         floatingLabelTextField.editingChanged()

--- a/SkyFloatingLabelTextField/SkyFloatingLabelTextFieldTests/SkyFloatingLabelTextFieldTests.swift
+++ b/SkyFloatingLabelTextField/SkyFloatingLabelTextFieldTests/SkyFloatingLabelTextFieldTests.swift
@@ -246,7 +246,7 @@ class SkyFloatingLabelTextFieldTests: XCTestCase {
         XCTAssertEqual(floatingLabelTextField.errorMessage, "Error")
     }
     
-    func test_whenEditingChangedInvoked_thenDelegateShouldChangeCharactersInRangeInvoked() {
+    func test_whenEditingChangedInvoked_thenDelegateShouldChangeCharactersInRangeIsNotInvoked() {
         // given
         floatingLabelTextField.delegate = textFieldDelegateMock
         floatingLabelTextField.text = "aa"
@@ -255,19 +255,7 @@ class SkyFloatingLabelTextFieldTests: XCTestCase {
         floatingLabelTextField.editingChanged()
         
         // then
-        XCTAssertTrue(textFieldDelegateMock.shouldChangeCharactersInRangeInvoked)
-    }
-    
-    func test_whenEditingChangedInvoked2_thenDelegateShouldChangeCharactersInRangeInvoked() {
-        // given
-        floatingLabelTextField.delegate = textFieldDelegateMock
-        floatingLabelTextField.text = nil
-        
-        // when
-        floatingLabelTextField.editingChanged()
-        
-        // then
-        XCTAssertTrue(textFieldDelegateMock.shouldChangeCharactersInRangeInvoked)
+        XCTAssertFalse(textFieldDelegateMock.shouldChangeCharactersInRangeInvoked)
     }
     
     // MARK:  - editingOrSelected

--- a/SkyFloatingLabelTextField/SkyFloatingLabelTextFieldTests/SkyFloatingLabelTextFieldTests.swift
+++ b/SkyFloatingLabelTextField/SkyFloatingLabelTextFieldTests/SkyFloatingLabelTextFieldTests.swift
@@ -83,6 +83,28 @@ class SkyFloatingLabelTextFieldTests: XCTestCase {
         XCTAssertEqual(floatingLabelTextField.titleLabel.textColor, self.customColor)
     }
     
+    func test_whenSettingErrorColor_withErrorMessageBeingEmpty_thenTitleLabelTextColorIsNotChangedToThisColor() {
+        // given
+        floatingLabelTextField.errorMessage = ""
+        
+        // when
+        floatingLabelTextField.errorColor = self.customColor
+        
+        // then
+        XCTAssertNotEqual(floatingLabelTextField.titleLabel.textColor, self.customColor)
+    }
+    
+    func test_whenSettingErrorColor_withErrorMessageBeingNil_thenTitleLabelTextColorIsNotChangedToThisColor() {
+        // given
+        floatingLabelTextField.errorMessage = nil
+        
+        // when
+        floatingLabelTextField.errorColor = self.customColor
+        
+        // then
+        XCTAssertNotEqual(floatingLabelTextField.titleLabel.textColor, self.customColor)
+    }
+    
     func test_whenSettingErrorColor_withErrorMessageBeingSet_thenLineViewBackgroundColorIsChangedToThisColor() {
         // given
         floatingLabelTextField.errorMessage = "test"

--- a/Sources/SkyFloatingLabelTextField.swift
+++ b/Sources/SkyFloatingLabelTextField.swift
@@ -200,7 +200,7 @@ public class SkyFloatingLabelTextField: UITextField {
     /// A Boolean value that determines whether the receiver has an error message.
     public var hasErrorMessage:Bool {
         get {
-            return self.errorMessage != nil
+            return self.errorMessage != nil && self.errorMessage != ""
         }
     }
     

--- a/Sources/SkyFloatingLabelTextField.swift
+++ b/Sources/SkyFloatingLabelTextField.swift
@@ -151,9 +151,6 @@ public class SkyFloatingLabelTextField: UITextField {
         }
     }
     
-    /// A Boolean value that determines whether the receiver discards `errorMessage` when the text input is changed.
-    public var discardsErrorMessageOnTextChange:Bool = true
-    
     /// The backing property for the highlighted property
     private var _highlighted = false
     
@@ -227,7 +224,6 @@ public class SkyFloatingLabelTextField: UITextField {
     @IBInspectable
     override public var text:String? {
         didSet {
-            self.resetErrorMessageIfPresent()
             self.updateControl(false)
         }
     }
@@ -301,7 +297,6 @@ public class SkyFloatingLabelTextField: UITextField {
      Invoked when the editing state of the textfield changes. Override to respond to this change.
      */
     public func editingChanged() {
-        self.resetErrorMessageIfPresent()
         updateControl(true)
         updateTitleLabel(true)
         let range = NSMakeRange(0, self.text?.characters.count ?? 0)
@@ -347,7 +342,6 @@ public class SkyFloatingLabelTextField: UITextField {
     */
     override public func becomeFirstResponder() -> Bool {
         let result = super.becomeFirstResponder()
-        self.resetErrorMessageIfPresent()
         self.updateControl(true)
         return result
     }
@@ -433,8 +427,11 @@ public class SkyFloatingLabelTextField: UITextField {
         }
         self.titleLabel.text = titleText
         
-        let titleVisible = (titleText != nil) && self.hasText()
-        self.setTitleVisibile(titleVisible, animated: animated)
+        self.setTitleVisibile(self.isTitleVisible(), animated: animated)
+    }
+    
+    public func isTitleVisible() -> Bool {
+        return self.hasText() || self.hasErrorMessage
     }
     
     private func updateTitleVisibility(animated:Bool = false, animateFromCurrentState:Bool = false) {
@@ -560,7 +557,7 @@ public class SkyFloatingLabelTextField: UITextField {
     override public func layoutSubviews() {
         super.layoutSubviews()
         
-        self.titleLabel.frame = self.titleLabelRectForBounds(self.bounds, editing: self.hasText() || _renderingInInterfaceBuilder)
+        self.titleLabel.frame = self.titleLabelRectForBounds(self.bounds, editing: self.isTitleVisible() || _renderingInInterfaceBuilder)
         self.lineView.frame = self.lineViewRectForBounds(self.bounds, editing: self.editingOrSelected || _renderingInInterfaceBuilder)
     }
     
@@ -581,12 +578,6 @@ public class SkyFloatingLabelTextField: UITextField {
             _titleVisible = false
             self.updateTitleVisibility(animated, animateFromCurrentState: true)
             self.updateLineView()
-        }
-    }
-    
-    private func resetErrorMessageIfPresent() {
-        if self.hasErrorMessage && discardsErrorMessageOnTextChange {
-            self.errorMessage = nil
         }
     }
     

--- a/Sources/SkyFloatingLabelTextField.swift
+++ b/Sources/SkyFloatingLabelTextField.swift
@@ -299,11 +299,6 @@ public class SkyFloatingLabelTextField: UITextField {
     public func editingChanged() {
         updateControl(true)
         updateTitleLabel(true)
-        if let text = self.text {
-            let range = NSMakeRange(0, text.characters.count)
-            // Because of subscribing to .EditingChanged, the error message was cleared for any delegate overriding the textField:shouldChangeCharactersInRange:replacementString method. Invoke this again to enable setting the error message on text change.
-            self.delegate?.textField?(self, shouldChangeCharactersInRange: range, replacementString: text)
-        }
     }
     
     // MARK: create components

--- a/Sources/SkyFloatingLabelTextField.swift
+++ b/Sources/SkyFloatingLabelTextField.swift
@@ -299,9 +299,11 @@ public class SkyFloatingLabelTextField: UITextField {
     public func editingChanged() {
         updateControl(true)
         updateTitleLabel(true)
-        let range = NSMakeRange(0, self.text?.characters.count ?? 0)
-        // Because of subscribing to .EditingChanged, the error message was cleared for any delegate overriding the textField:shouldChangeCharactersInRange:replacementString method. Invoke this again to enable setting the error message on text change.
-        self.delegate?.textField?(self, shouldChangeCharactersInRange: range, replacementString: self.text ?? "")
+        if let text = self.text {
+            let range = NSMakeRange(0, text.characters.count)
+            // Because of subscribing to .EditingChanged, the error message was cleared for any delegate overriding the textField:shouldChangeCharactersInRange:replacementString method. Invoke this again to enable setting the error message on text change.
+            self.delegate?.textField?(self, shouldChangeCharactersInRange: range, replacementString: text)
+        }
     }
     
     // MARK: create components


### PR DESCRIPTION
This PR addresses [Issue 23](https://github.com/Skyscanner/SkyFloatingLabelTextField/issues/23) and [Issue 27](https://github.com/Skyscanner/SkyFloatingLabelTextField/issues/27)

Before this change there was some "hidden" business logic around the resetting of `errorMessage`, namely:
- Whenever the control was selected by a user, it got cleared (`becomeFirstResponder` invoked)
- Whenever the text changed, it also got reset (when `textField(textField:,range:string:)` was invoked)

After this change what's different:
- The `errorMessage` is no longer reset by any text or focus changes. If a developer sets this message, the error will be displayed, until this property is cleared. To implement the previous functionality, just subscribe to the `textField(textField:,range:string:)` event on the delegate
- As a side effect of this, the workaround of double-invoking  `textField(textField:,range:string:)` has been removed, fixing the bug raised by [Issue 27](https://github.com/Skyscanner/SkyFloatingLabelTextField/issues/27)

Examples have also been updated to allow clearing of the error message:
![](https://i.gyazo.com/a345e5fd59343ec16f7985b6fdf356c8.gif)