### PR TITLE
Add updatePlaceholder to placeholder's didSet

### DIFF
--- a/Sources/SkyFloatingLabelTextField.swift
+++ b/Sources/SkyFloatingLabelTextField.swift
@@ -250,6 +250,7 @@ public class SkyFloatingLabelTextField: UITextField {
     override public var placeholder:String? {
         didSet {
             self.setNeedsDisplay()
+            self.updatePlaceholder()
             self.updateTitleLabel()
         }
     }


### PR DESCRIPTION
Without it, the placeholder is not visible when using Interface Builder. Placeholder is not set when the view is created and updatePlaceholder is not invoked after setting placeholder either in code or Interface Builder