### PR TITLE
Added Carthage/Build to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,8 @@ DerivedData
 #
 # Pods/
 
+# Carthage
+Carthage/Build
 
 ### Xcode ###
 build/


### PR DESCRIPTION
When using the option `--use-submodules` with Carthage, the `Carthage/Build` directory shows in the submodule after `carthage build` making the submodule dirty.