### PR TITLE
[Travis] Prelaunch iOS simulator before tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,9 @@ xcode_sdk: iphonesimulator9.3
 before_install:
     - gem install specific_install
     - gem specific_install -l https://github.com/venmo/slather.git
-#    - gem install slather --no-rdoc --no-ri --no-document --quiet
+    - export IOS_SIMULATOR_UDID=$(instruments -s devices | grep "$ios_device ($ios_version)" | sed -E 's/.*\[([0-9A-F-]+)\].*/\1/g')
+    - echo "Prelaunching iOS simulator $IOS_SIMULATOR_UDID"
+    - open -a "simulator" --args -CurrentDeviceUDID $IOS_SIMULATOR_UDID
 
 script:
 - xcodebuild clean build test -project SkyFloatingLabelTextField/SkyFloatingLabelTextField.xcodeproj -scheme SkyFloatingLabelTextField -destination 'platform=iOS Simulator,name=iPhone 6,OS=9.3' GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES GCC_GENERATE_TEST_COVERAGE_FILES=YES


### PR DESCRIPTION
Fixes the issue with `Exit status 65` for us, as far as I understand there is an issue with xcodebuild. 

Using Fastlane's Scan [solution](https://github.com/fastlane/fastlane/pull/5530/files) works and another solution from Travis [issue](https://github.com/travis-ci/travis-ci/issues/6422#issuecomment-261619205).