### PR TITLE
[Travis] Update Xcode version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ branches:
 
 xcode_project: SkyFloatingLabelTextField/SkyFloatingLabelTextField.xcodeproj
 xcode_scheme: SkyFloatingLabelTextField
-osx_image: xcode7.3
-xcode_sdk: iphonesimulator9.3
+osx_image: xcode8.1
+xcode_sdk: iphonesimulator10.1
 
 before_install:
     - gem install specific_install


### PR DESCRIPTION
By updating Xcode we fix #38, the travis file is set to use the lastest `slather` version already.