### PR TITLE
@discardableResult for becomeFirstResponder() and resignFirstResponder()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Master(unreleased)
 -----------------
 
-
+* Added `@discardableResult` to `becomeFirstResponder` and `resignFirstResponder`. This silences Xcode warnings about unused results of those functions and brings the implementation closer to the iOS API.
 
 v2.0
 ----

--- a/SkyFloatingLabelTextField/SkyFloatingLabelTextFieldExample/Example0/ShowcaseExampleViewController.swift
+++ b/SkyFloatingLabelTextField/SkyFloatingLabelTextFieldExample/Example0/ShowcaseExampleViewController.swift
@@ -28,7 +28,7 @@ class ShowcaseExampleViewController: UIViewController, UITextFieldDelegate {
         
         self.setupThemeColors()
         
-        _ = self.departureCityField.becomeFirstResponder()
+        self.departureCityField.becomeFirstResponder()
     }
     
     // MARK: - Creating the form elements

--- a/SkyFloatingLabelTextField/SkyFloatingLabelTextFieldExample/Example1/SettingTextsViewController.swift
+++ b/SkyFloatingLabelTextField/SkyFloatingLabelTextFieldExample/Example1/SettingTextsViewController.swift
@@ -25,7 +25,7 @@ class SettingTextsViewController: UIViewController {
     }
     
     @IBAction func resignTextField() {
-        _ = self.textField?.resignFirstResponder()
+        self.textField?.resignFirstResponder()
     }
     
     @IBAction func selectedTitleChanged(_ segmentedControl:UISegmentedControl) {

--- a/SkyFloatingLabelTextField/SkyFloatingLabelTextFieldExample/Example2/CustomizingColorsViewController.swift
+++ b/SkyFloatingLabelTextField/SkyFloatingLabelTextFieldExample/Example2/CustomizingColorsViewController.swift
@@ -25,7 +25,7 @@ class CustomizingColorsViewController: UIViewController {
     }
     
     @IBAction func resignTextField() {
-        _ = self.textField?.resignFirstResponder()
+        self.textField?.resignFirstResponder()
     }
     
     @IBAction func titleColorChanged(_ segmentedControl:UISegmentedControl) {

--- a/SkyFloatingLabelTextField/SkyFloatingLabelTextFieldExample/Example3/SubclassingViewController.swift
+++ b/SkyFloatingLabelTextField/SkyFloatingLabelTextFieldExample/Example3/SubclassingViewController.swift
@@ -33,6 +33,6 @@ class SubclassingViewController: UIViewController {
     }
     
     @IBAction func resignTextField() {
-        _ = self.textField?.resignFirstResponder()
+        self.textField?.resignFirstResponder()
     }
 }

--- a/SkyFloatingLabelTextField/SkyFloatingLabelTextFieldExample/Example4/CustomLayoutViewController.swift
+++ b/SkyFloatingLabelTextField/SkyFloatingLabelTextFieldExample/Example4/CustomLayoutViewController.swift
@@ -25,7 +25,7 @@ class CustomLayoutViewController: UIViewController {
     }
     
     @IBAction func resignTextField() {
-        _ = self.textField?.resignFirstResponder()
+        self.textField?.resignFirstResponder()
     }
 
 }

--- a/SkyFloatingLabelTextField/SkyFloatingLabelTextFieldExample/Example5/DelegateMethodsViewController.swift
+++ b/SkyFloatingLabelTextField/SkyFloatingLabelTextFieldExample/Example5/DelegateMethodsViewController.swift
@@ -33,7 +33,7 @@ class DelegateMethodsViewController: UIViewController, UITextFieldDelegate {
     }
     
     @IBAction func resignTextField() {
-        _ = self.textField?.resignFirstResponder()
+        self.textField?.resignFirstResponder()
     }
     
     func log(text:String) {

--- a/SkyFloatingLabelTextField/SkyFloatingLabelTextFieldTests/SkyFloatingLabelTextFieldTests.swift
+++ b/SkyFloatingLabelTextField/SkyFloatingLabelTextFieldTests/SkyFloatingLabelTextFieldTests.swift
@@ -229,7 +229,7 @@ class SkyFloatingLabelTextFieldTests: XCTestCase {
         floatingLabelTextField.errorMessage = "Error"
         
         // when
-        _ = floatingLabelTextField.becomeFirstResponder()
+        floatingLabelTextField.becomeFirstResponder()
         
         // then
         XCTAssertEqual(floatingLabelTextField.errorMessage, "Error")
@@ -433,7 +433,7 @@ class SkyFloatingLabelTextFieldTests: XCTestCase {
         let floatingLabelTextFieldSpy = SkyFloatingLabelTextFieldSpy()
         
         // when
-        _ = floatingLabelTextFieldSpy.becomeFirstResponder()
+        floatingLabelTextFieldSpy.becomeFirstResponder()
         
         // then
         XCTAssertTrue(floatingLabelTextFieldSpy.updateColorsInvoked)
@@ -444,7 +444,7 @@ class SkyFloatingLabelTextFieldTests: XCTestCase {
         let floatingLabelTextFieldSpy = SkyFloatingLabelTextFieldSpy()
         
         // when
-        _ = floatingLabelTextFieldSpy.resignFirstResponder()
+        floatingLabelTextFieldSpy.resignFirstResponder()
         
         // then
         XCTAssertTrue(floatingLabelTextFieldSpy.updateColorsInvoked)

--- a/Sources/SkyFloatingLabelTextField.swift
+++ b/Sources/SkyFloatingLabelTextField.swift
@@ -315,7 +315,8 @@ open class SkyFloatingLabelTextField: UITextField {
      Attempt the control to become the first responder
      - returns: True when successfull becoming the first responder
     */
-    @discardableResult override open func becomeFirstResponder() -> Bool {
+    @discardableResult
+    override open func becomeFirstResponder() -> Bool {
         let result = super.becomeFirstResponder()
         self.updateControl(true)
         return result
@@ -325,7 +326,8 @@ open class SkyFloatingLabelTextField: UITextField {
      Attempt the control to resign being the first responder
      - returns: True when successfull resigning being the first responder
      */
-    @discardableResult override open func resignFirstResponder() -> Bool {
+    @discardableResult
+    override open func resignFirstResponder() -> Bool {
         let result =  super.resignFirstResponder()
         self.updateControl(true)
         return result

--- a/Sources/SkyFloatingLabelTextField.swift
+++ b/Sources/SkyFloatingLabelTextField.swift
@@ -315,7 +315,7 @@ open class SkyFloatingLabelTextField: UITextField {
      Attempt the control to become the first responder
      - returns: True when successfull becoming the first responder
     */
-    override open func becomeFirstResponder() -> Bool {
+    @discardableResult override open func becomeFirstResponder() -> Bool {
         let result = super.becomeFirstResponder()
         self.updateControl(true)
         return result
@@ -325,7 +325,7 @@ open class SkyFloatingLabelTextField: UITextField {
      Attempt the control to resign being the first responder
      - returns: True when successfull resigning being the first responder
      */
-    override open func resignFirstResponder() -> Bool {
+    @discardableResult override open func resignFirstResponder() -> Bool {
         let result =  super.resignFirstResponder()
         self.updateControl(true)
         return result


### PR DESCRIPTION
When calling `textField.becomeFirstResponder()` or `textField.resignFirstResponder()` Xcode warns:
> Result of call to 'becomeFirstResponder()' is unused
> Result of call to 'resignFirstResponder()' is unused

In the example code this is avoided by prefixing all instances with `_ = ...`, but i like to keep my code clean, so the better solution is to add `@discardableResult` to those functions in source. This way the result can be used just like before, if needed, but it doesn't have to be used.