### PR TITLE
Pass completion flag to callbacks for animations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,28 @@
 Master(unreleased)
 -----------------
 
+### Breaking
+
+Change implementation of anmimation callbacks to include boolean completed flag. 
+
+#### Before
+```swift
+textfield.setTitleVisible(false, animated: true) {
+	// Perform callback actions
+}
+```
+
+#### Now
+
+```swift
+textfield.setTitleVisible(false, animated: true) { completed in
+	// Do callback actions using completed flag 
+}
+```
+
+See (#112)[https://github.com/Skyscanner/SkyFloatingLabelTextField/pull/112]
+
+
 v2.0.1
 ------
 

--- a/SkyFloatingLabelTextField/SkyFloatingLabelTextFieldExample/Example0/ShowcaseExampleViewController.swift
+++ b/SkyFloatingLabelTextField/SkyFloatingLabelTextFieldExample/Example0/ShowcaseExampleViewController.swift
@@ -149,7 +149,7 @@ class ShowcaseExampleViewController: UIViewController, UITextFieldDelegate {
         }
     }
     
-    func showingTitleInAnimationComplete() {
+    func showingTitleInAnimationComplete(_ completed: Bool) {
         // If a field is not filled out, display the highlighted title for 0.3 seco
         DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.3) {
             self.showingTitleInProgress = false

--- a/Sources/SkyFloatingLabelTextField.swift
+++ b/Sources/SkyFloatingLabelTextField.swift
@@ -412,7 +412,7 @@ open class SkyFloatingLabelTextField: UITextField {
     /*
     *   Set this value to make the title visible
     */
-    open func setTitleVisible(_ titleVisible:Bool, animated:Bool = false, animationCompletion: (()->())? = nil) {
+    open func setTitleVisible(_ titleVisible:Bool, animated:Bool = false, animationCompletion: ((_ completed: Bool) -> Void)? = nil) {
         if(_titleVisible == titleVisible) {
             return
         }
@@ -429,7 +429,7 @@ open class SkyFloatingLabelTextField: UITextField {
         return self.hasText || self.hasErrorMessage || _titleVisible
     }
 
-    fileprivate func updateTitleVisibility(_ animated:Bool = false, completion: (()->())? = nil) {
+    fileprivate func updateTitleVisibility(_ animated:Bool = false, completion: ((_ completed: Bool) -> Void)? = nil) {
         let alpha:CGFloat = self.isTitleVisible() ? 1.0 : 0.0
         let frame:CGRect = self.titleLabelRectForBounds(self.bounds, editing: self.isTitleVisible())
         let updateBlock = { () -> Void in
@@ -442,12 +442,10 @@ open class SkyFloatingLabelTextField: UITextField {
 
             UIView.animate(withDuration: duration, delay: 0, options: animationOptions, animations: { () -> Void in
                 updateBlock()
-                }, completion: { _ in
-                    completion?()
-                })
+                }, completion: completion)
         } else {
             updateBlock()
-            completion?()
+            completion?(true)
         }
     }
 


### PR DESCRIPTION
Previously the completed value from
`UIView.animate` was not passed to the callback in
`setTitleVisible(_ titleVisible:, animated:, animationCompletion:)`,
it is now.

cc @bogren 