### PR TITLE
Silencing warnings by changing M_PI to .pi

### DIFF
--- a/SkyFloatingLabelTextField/SkyFloatingLabelTextFieldTests/SkyFloatingLabelTextFieldWithIconTests.swift
+++ b/SkyFloatingLabelTextField/SkyFloatingLabelTextFieldTests/SkyFloatingLabelTextFieldWithIconTests.swift
@@ -80,7 +80,7 @@ class SkyFloatingLabelTextFieldWithIconTests: XCTestCase {
         floatingLabelTextFieldWithIcon.iconRotationDegrees = 45
         
         // then
-        let expectedTransform = CGAffineTransform(rotationAngle: CGFloat(45.0 * M_PI / 180.0))
+        let expectedTransform = CGAffineTransform(rotationAngle: CGFloat(45.0 * .pi / 180.0))
         XCTAssertEqual(floatingLabelTextFieldWithIcon.iconLabel.transform.a, expectedTransform.a)
         XCTAssertEqual(floatingLabelTextFieldWithIcon.iconLabel.transform.b, expectedTransform.b)
         XCTAssertEqual(floatingLabelTextFieldWithIcon.iconLabel.transform.c, expectedTransform.c)

--- a/Sources/SkyFloatingLabelTextFieldWithIcon.swift
+++ b/Sources/SkyFloatingLabelTextFieldWithIcon.swift
@@ -74,7 +74,7 @@ open class SkyFloatingLabelTextFieldWithIcon: SkyFloatingLabelTextField {
     @IBInspectable
     open var iconRotationDegrees:Double = 0 {
         didSet {
-            self.iconLabel.transform = CGAffineTransform(rotationAngle: CGFloat(iconRotationDegrees * M_PI / 180.0))
+            self.iconLabel.transform = CGAffineTransform(rotationAngle: CGFloat(iconRotationDegrees * .pi / 180.0))
         }
     }
     


### PR DESCRIPTION
Xcode 8.3 is displaying warnings about M_PI being deprecated. This silences the warnings by using the suggested static var pi on Double.