### PR TITLE
Disabled code coverage for xCode 9

### DIFF
--- a/SkyFloatingLabelTextField/SkyFloatingLabelTextField.xcodeproj/xcshareddata/xcschemes/SkyFloatingLabelTextField.xcscheme
+++ b/SkyFloatingLabelTextField/SkyFloatingLabelTextField.xcodeproj/xcshareddata/xcschemes/SkyFloatingLabelTextField.xcscheme
@@ -26,8 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      language = ""
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -56,6 +56,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"


### PR DESCRIPTION
Cannot submit to app store if code coverage is enabled. This happens when using Carthage.

Code Coverage has been disabled

For more information please see:

https://github.com/Carthage/Carthage/issues/2056