### PR TITLE
Fix crash caused by nil lineView and titleLabel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Master
 ------
 
+* Fixed crash when overriding certain properties [#216](https://github.com/Skyscanner/SkyFloatingLabelTextField/pull/216). Thanks to [alextov](https://github.com/alextov).
+
 v3.5.1
 ------
 

--- a/Sources/SkyFloatingLabelTextField.swift
+++ b/Sources/SkyFloatingLabelTextField.swift
@@ -411,9 +411,11 @@ open class SkyFloatingLabelTextField: UITextField { // swiftlint:disable:this ty
     }
 
     fileprivate func updateLineView() {
-        if let lineView = lineView {
-            lineView.frame = lineViewRectForBounds(bounds, editing: editingOrSelected)
+        guard let lineView = lineView else {
+            return
         }
+
+        lineView.frame = lineViewRectForBounds(bounds, editing: editingOrSelected)
         updateLineColor()
     }
 
@@ -427,6 +429,10 @@ open class SkyFloatingLabelTextField: UITextField { // swiftlint:disable:this ty
     }
 
     fileprivate func updateLineColor() {
+        guard let lineView = lineView else {
+            return
+        }
+
         if !isEnabled {
             lineView.backgroundColor = disabledColor
         } else if hasErrorMessage {
@@ -437,6 +443,10 @@ open class SkyFloatingLabelTextField: UITextField { // swiftlint:disable:this ty
     }
 
     fileprivate func updateTitleColor() {
+        guard let titleLabel = titleLabel else {
+            return
+        }
+
         if !isEnabled {
             titleLabel.textColor = disabledColor
         } else if hasErrorMessage {
@@ -463,6 +473,9 @@ open class SkyFloatingLabelTextField: UITextField { // swiftlint:disable:this ty
     // MARK: - Title handling
 
     fileprivate func updateTitleLabel(_ animated: Bool = false) {
+        guard let titleLabel = titleLabel else {
+            return
+        }
 
         var titleText: String? = nil
         if hasErrorMessage {


### PR DESCRIPTION
When creating `SkyFloatingLabelTextField` from storyboard and overriding certain properties, it is possible to get an `Unexpectedly found nil while unwrapping an Optional value` fatal error in `updateLineColor()` and some other methods.

Here is a minimal working example:

```swift
import SkyFloatingLabelTextField
import UIKit

final class ViewController: UIViewController {

    @IBOutlet private weak var textField: SkyFloatingLabelTextField!

}

extension SkyFloatingLabelTextField {

    override open var isSecureTextEntry: Bool {
        didSet {
            textColor = isSecureTextEntry ? .blue : .red
        }
    }

}
```

([Full Xcode project](https://github.com/Skyscanner/SkyFloatingLabelTextField/files/2123485/poc.zip).)

The proposed pull request solves this issue by performing optional unwrapping with `guard`s.

I didn’t check all places where implicit option unwrapping occurs, so there may be other crashes left related to this issue. To properly address it I was thinking to rewrite the component to have pairs of optional and non-optional properties (e.g., optional `customLineView` and non-optional `lineView`). That way user will still be able to customize the respective views and there will be a reliable fallback option. It is out of scope of this pull request, but if you deem it useful I can explore it further and prepare a separate proposal.