### PR TITLE
Fix for Xcode 9.4.1

### DIFF
--- a/Sources/SkyFloatingLabelTextField.swift
+++ b/Sources/SkyFloatingLabelTextField.swift
@@ -219,6 +219,7 @@ open class SkyFloatingLabelTextField: UITextField { // swiftlint:disable:this ty
     }
 
     /// A String value for the error message to display.
+    @IBInspectable
     open var errorMessage: String? {
         didSet {
             updateControl(true)


### PR DESCRIPTION
In Xcode 9.4.1 property errorMessage is not accessible from Objective-C code