### PR TITLE
Remove SwiftLint warnings

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -17,3 +17,7 @@ included:
   - Package.swift
 excluded:
 
+explicit_type_interface:
+  excluded: 
+    - local
+  severity: warning

--- a/SkyFloatingLabelTextField.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/SkyFloatingLabelTextField.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/SkyFloatingLabelTextField/SkyFloatingLabelTextField.xcodeproj/project.pbxproj
+++ b/SkyFloatingLabelTextField/SkyFloatingLabelTextField.xcodeproj/project.pbxproj
@@ -209,7 +209,10 @@
 				F547D4AD1C3BEA900075A0C2 /* SkyFloatingLabelTextFieldExample */,
 				F56289191C3BE3A20082D9A6 /* Products */,
 			);
+			indentWidth = 4;
 			sourceTree = "<group>";
+			tabWidth = 4;
+			usesTabs = 0;
 		};
 		F56289191C3BE3A20082D9A6 /* Products */ = {
 			isa = PBXGroup;

--- a/SkyFloatingLabelTextField/SkyFloatingLabelTextFieldExample/Example1/SettingTextsViewController.swift
+++ b/SkyFloatingLabelTextField/SkyFloatingLabelTextFieldExample/Example1/SettingTextsViewController.swift
@@ -58,12 +58,12 @@ class SettingTextsViewController: UIViewController {
 
     @IBAction func selectedTitleChanged(_ segmentedControl: UISegmentedControl) {
         switch segmentedControl.selectedSegmentIndex {
-            case 0:
-                textField?.selectedTitle = nil
-            case 1:
-                textField?.selectedTitle = "Selected title"
-            default:
-                break
+        case 0:
+            textField?.selectedTitle = nil
+        case 1:
+            textField?.selectedTitle = "Selected title"
+        default:
+            break
         }
     }
 

--- a/SkyFloatingLabelTextField/SkyFloatingLabelTextFieldTests/SkyFloatingLabelTextFieldTests.swift
+++ b/SkyFloatingLabelTextField/SkyFloatingLabelTextFieldTests/SkyFloatingLabelTextFieldTests.swift
@@ -106,14 +106,14 @@ class SkyFloatingLabelTextFieldTests: XCTestCase { // swiftlint:disable:this typ
     func test_whenSettingTitleErrorColor_withErrorMessageBeingSet_thenTitleLabelTextColorIsChangedToThisColor() {
         // given
         floatingLabelTextField.errorMessage = "test"
-        
+
         // when
         floatingLabelTextField.titleErrorColor = self.customColor
-        
+
         // then
         XCTAssertEqual(floatingLabelTextField.titleLabel.textColor, self.customColor)
     }
-    
+
     func test_whenSettingErrorColor_withErrorMessageBeingEmpty_thenTitleLabelTextColorIsNotChangedToThisColor() {
         // given
         floatingLabelTextField.errorMessage = ""
@@ -128,14 +128,14 @@ class SkyFloatingLabelTextFieldTests: XCTestCase { // swiftlint:disable:this typ
     func test_whenSettingTitleErrorColor_withErrorMessageBeingEmpty_thenTitleLabelTextColorIsNotChangedToThisColor() {
         // given
         floatingLabelTextField.errorMessage = ""
-        
+
         // when
         floatingLabelTextField.titleErrorColor = self.customColor
-        
+
         // then
         XCTAssertNotEqual(floatingLabelTextField.titleLabel.textColor, self.customColor)
     }
-    
+
     func test_whenSettingErrorColor_withErrorMessageBeingNil_thenTitleLabelTextColorIsNotChangedToThisColor() {
         // given
         floatingLabelTextField.errorMessage = nil
@@ -150,14 +150,14 @@ class SkyFloatingLabelTextFieldTests: XCTestCase { // swiftlint:disable:this typ
     func test_whenSettingTitleErrorColor_withErrorMessageBeingNil_thenTitleLabelTextColorIsNotChangedToThisColor() {
         // given
         floatingLabelTextField.errorMessage = nil
-        
+
         // when
         floatingLabelTextField.titleErrorColor = self.customColor
-        
+
         // then
         XCTAssertNotEqual(floatingLabelTextField.titleLabel.textColor, self.customColor)
     }
-    
+
     func test_whenSettingErrorColor_withErrorMessageBeingSet_thenLineViewBackgroundColorIsChangedToThisColor() {
         // given
         floatingLabelTextField.errorMessage = "test"
@@ -172,14 +172,14 @@ class SkyFloatingLabelTextFieldTests: XCTestCase { // swiftlint:disable:this typ
     func test_whenSettingLineErrorColor_withErrorMessageBeingSet_thenLineViewBackgroundColorIsChangedToThisColor() {
         // given
         floatingLabelTextField.errorMessage = "test"
-        
+
         // when
         floatingLabelTextField.lineErrorColor = self.customColor
-        
+
         // then
         XCTAssertEqual(floatingLabelTextField.lineView.backgroundColor, self.customColor)
     }
-    
+
     func test_whenSettingSelectedTitleColor_withTextfieldBeingSelected_thenTitleLabelTextColorIsChangedToThisColor() {
         // given
         floatingLabelTextField.isSelected = true
@@ -742,7 +742,7 @@ class SkyFloatingLabelTextFieldTests: XCTestCase { // swiftlint:disable:this typ
         let result = floatingLabelTextField.delegate!.textField!(
             floatingLabelTextField,
             shouldChangeCharactersIn: NSRange(),
-            replacementString:""
+            replacementString: ""
         )
 
         // then

--- a/SkyFloatingLabelTextFieldObjectiveCExample/Pods/SkyFloatingLabelTextField/Sources/SkyFloatingLabelTextField.swift
+++ b/SkyFloatingLabelTextFieldObjectiveCExample/Pods/SkyFloatingLabelTextField/Sources/SkyFloatingLabelTextField.swift
@@ -399,7 +399,7 @@ open class SkyFloatingLabelTextField: UITextField { // swiftlint:disable:this ty
 
     fileprivate func updateTitleLabel(_ animated: Bool = false) {
 
-        var titleText: String? = nil
+        var titleText: String?
         if hasErrorMessage {
             titleText = titleFormatter(errorMessage!)
         } else {

--- a/Sources/SkyFloatingLabelTextField.swift
+++ b/Sources/SkyFloatingLabelTextField.swift
@@ -127,21 +127,21 @@ open class SkyFloatingLabelTextField: UITextField { // swiftlint:disable:this ty
             updateColors()
         }
     }
-    
+
     /// A UIColor value that determines the color used for the text when error message is not `nil`
     @IBInspectable dynamic open var textErrorColor: UIColor? {
         didSet {
             updateColors()
         }
     }
-    
+
     /// A UIColor value that determines the color used for the title label when error message is not `nil`
     @IBInspectable dynamic open var titleErrorColor: UIColor? {
         didSet {
             updateColors()
         }
     }
-    
+
     /// A UIColor value that determines the color used for the title label and line when text field is disabled
     @IBInspectable dynamic open var disabledColor: UIColor = UIColor(white: 0.88, alpha: 1.0) {
         didSet {
@@ -478,7 +478,7 @@ open class SkyFloatingLabelTextField: UITextField { // swiftlint:disable:this ty
             return
         }
 
-        var titleText: String? = nil
+        var titleText: String?
         if hasErrorMessage {
             titleText = titleFormatter(errorMessage!)
         } else {
@@ -643,7 +643,7 @@ open class SkyFloatingLabelTextField: UITextField { // swiftlint:disable:this ty
             return 0.0
         }
 
-        return font.lineHeight + 7.0;
+        return font.lineHeight + 7.0
     }
 
     // MARK: - Layout


### PR DESCRIPTION
1. Remove 166 violations in 22 files generated by SwiftLint
2. Add `IDEWorkspaceChecks.plist` generated by XCode 9.3+
3. Configure project indentation for those whose indentation options in XCode differs