### PR TITLE
Selected Title Font

### DIFF
--- a/Sources/SkyFloatingLabelTextField.swift
+++ b/Sources/SkyFloatingLabelTextField.swift
@@ -163,6 +163,13 @@ open class SkyFloatingLabelTextField: UITextField { // swiftlint:disable:this ty
             updateTitleColor()
         }
     }
+    
+    /// A UIFont value that determines text color of the placeholder label
+    @objc dynamic open var selectedTitleFont: UIFont = .systemFont(ofSize: 13) {
+        didSet {
+            updateTitleLabel()
+        }
+    }
 
     /// A UIColor value that determines the color of the line in a selected state
     @IBInspectable dynamic open var selectedLineColor: UIColor = .black {
@@ -351,7 +358,7 @@ open class SkyFloatingLabelTextField: UITextField { // swiftlint:disable:this ty
     fileprivate func createTitleLabel() {
         let titleLabel = UILabel()
         titleLabel.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-        titleLabel.font = titleFont
+        titleLabel.font = selectedTitleFont
         titleLabel.alpha = 0.0
         titleLabel.textColor = titleColor
 
@@ -499,7 +506,7 @@ open class SkyFloatingLabelTextField: UITextField { // swiftlint:disable:this ty
             }
         }
         titleLabel.text = titleText
-        titleLabel.font = titleFont
+        titleLabel.font = selectedTitleFont
 
         updateTitleVisibility(animated)
     }

--- a/Sources/SkyFloatingLabelTextField.swift
+++ b/Sources/SkyFloatingLabelTextField.swift
@@ -163,8 +163,8 @@ open class SkyFloatingLabelTextField: UITextField { // swiftlint:disable:this ty
             updateTitleColor()
         }
     }
-    
-    /// A UIFont value that determines text color of the placeholder label
+
+    /// A UIFont value that determines text font of the title label when editing
     @objc dynamic open var selectedTitleFont: UIFont = .systemFont(ofSize: 13) {
         didSet {
             updateTitleLabel()


### PR DESCRIPTION
Added a property to customize the title label font when editing. I called it `selectedTitleFont` to match `selectedTitleColor`. An example of usage:

```swift
font = UIFont.lightP1RegularLeft
selectedTitleFont = UIFont.grayP3RegularLeft
```

![2019-01-07 22 09 22](https://user-images.githubusercontent.com/177740/50796272-ec603d00-12c8-11e9-9ded-c36ca1be31c9.gif)