### PR TITLE
Correct param name in code doc comment to remove warning

### DIFF
--- a/Sources/SkyFloatingLabelTextField.swift
+++ b/Sources/SkyFloatingLabelTextField.swift
@@ -318,7 +318,7 @@ open class SkyFloatingLabelTextField: UITextField { // swiftlint:disable:this ty
 
     /**
      Intialzies the control by deserializing it
-     - parameter coder the object to deserialize the control from
+     - parameter aDecoder the object to deserialize the control from
      */
     required public init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)

--- a/Sources/SkyFloatingLabelTextFieldWithIcon.swift
+++ b/Sources/SkyFloatingLabelTextFieldWithIcon.swift
@@ -175,7 +175,7 @@ open class SkyFloatingLabelTextFieldWithIcon: SkyFloatingLabelTextField {
 
     /**
      Intialzies the control by deserializing it
-     - parameter coder the object to deserialize the control from
+     - parameter aDecoder the object to deserialize the control from
      */
     required public init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)


### PR DESCRIPTION
This PR fixes a warning generated due to some code comment documentation being out of sync with the method signature it's documenting:

```json
{
    "file_name": "SkyFloatingLabelTextField-Swift.h",
    "file_path": "/Users/distiller/Library/Developer/Xcode/DerivedData/FCUKInvestors-ayldimmlknuroufijwwjlazdffcz/Build/Products/Debug-iphonesimulator/SkyFloatingLabelTextField/SkyFloatingLabelTextField.framework/Headers/SkyFloatingLabelTextField-Swift.h:252:12",
    "reason": "parameter 'coder' not found in the function declaration [-Wdocumentation]",
    "line": "/// \\param coder the object to deserialize the control from ",
    "cursor": "           ^~~~~"
}
```