### PR TITLE
Added full support for the swift package manager

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,16 +1,23 @@
-//  Copyright 2016 Skyscanner Ltd
-//
-//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with 
-//  the License. You may obtain a copy of the License at
-//
-//  http://www.apache.org/licenses/LICENSE-2.0
-//
-//  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed 
-//  on an "AS IS" WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the 
-//  specific language governing permissions and limitations under the License.
+// swift-tools-version:5.1
 
 import PackageDescription
 
 let package = Package(
-  name: "SkyFloatingLabelTextField"
+    name: "SkyFloatingLabelTextField",
+    platforms: [.iOS("8.0")],
+    products: [
+      .library(name: "SkyFloatingLabelTextField", targets: ["SkyFloatingLabelTextField"])
+    ],
+    targets: [
+        .target(
+            name: "SkyFloatingLabelTextField",
+            path: "Sources"
+        ),
+        .testTarget(
+            name: "SkyFloatingLabelTextFieldTests",
+            dependencies: ["SkyFloatingLabelTextField"],
+            path: "SkyFloatingLabelTextField/SkyFloatingLabelTextFieldTests"
+        ),
+    ],
+    swiftLanguageVersions: [.v4_2]
 )

--- a/SkyFloatingLabelTextField/SkyFloatingLabelTextFieldTests/SkyFloatingLabelTextFieldWithIconTests.swift
+++ b/SkyFloatingLabelTextField/SkyFloatingLabelTextFieldTests/SkyFloatingLabelTextFieldWithIconTests.swift
@@ -47,11 +47,14 @@ class SkyFloatingLabelTextFieldWithIconTests: XCTestCase {
     }
 
     func test_whenSettingIconImage_thenImageAppliedToIconImageView() {
+        // given
+        let customImage = UIImage()
+
         // when
-        floatingLabelTextFieldWithIcon.iconImage = #imageLiteral(resourceName: "SkyScannerIcon")
+        floatingLabelTextFieldWithIcon.iconImage = customImage
 
         // then
-        XCTAssertEqual(floatingLabelTextFieldWithIcon.iconImageView.image, #imageLiteral(resourceName: "SkyScannerIcon"))
+        XCTAssertEqual(floatingLabelTextFieldWithIcon.iconImageView.image, customImage)
     }
 
     func test_whenSettingIconColor_thenColorAppliedToIconLabel() {


### PR DESCRIPTION
In this PR:
- Added full support for the swift package manager.
- Had to change the tests to not use image literal, as SPM does not support resources.

For completing this PR, the naming scheme of the tags has to be changed: seems like SPM does not support a tag like `v3.7.0`: the `v` prefix has to be removed. See a related discussion in https://github.com/groue/GRDB.swift/issues/72#issuecomment-237459566. This issue is also mentioned in https://github.com/Skyscanner/SkyFloatingLabelTextField/issues/288#issuecomment-516776571.