### PR TITLE
Fix the editing field X position for RTL languages

### DIFF
--- a/Sources/SkyFloatingLabelTextFieldWithIcon.swift
+++ b/Sources/SkyFloatingLabelTextFieldWithIcon.swift
@@ -277,7 +277,7 @@ open class SkyFloatingLabelTextFieldWithIcon: SkyFloatingLabelTextField {
         if isLTRLanguage {
             rect.origin.x += CGFloat(iconWidth + iconMarginLeft)
         } else {
-            rect.origin.x -= CGFloat(iconWidth + iconMarginLeft)
+            // don't change the editing field X position for RTL languages
         }
         rect.size.width -= CGFloat(iconWidth + iconMarginLeft)
         return rect


### PR DESCRIPTION
Previously, a minus left margin is added to the editing field in RTL which is abnormal positioning.